### PR TITLE
Made User-Agent headers propagate to requests.get

### DIFF
--- a/livescrape.py
+++ b/livescrape.py
@@ -123,6 +123,8 @@ class ScrapedPage(object):
 
     @property
     def scrape_session(self):
+        if 'User-Agent' in self.scrape_headers:
+            SHARED_SESSION.headers['User-Agent'] = self.scrape_headers['User-Agent']
         return SHARED_SESSION
 
     def scrape_fetch(self, url):


### PR DESCRIPTION
Livescrape wasn't passing user defined headers to the requests.get call - all http requests had default requests user agent. This change fixes this.
